### PR TITLE
P014

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Note, all problems were solved without AI assistance, however AI was used to hel
 | P011 - Container With Most Water | 6 | 100% |  |
 | P012 - Integer to Roman | 1 | 100% |  |
 | P013 - Roman to Integer | 1 | 100% |  |
+| P014 - Longest Common Prefix | 0 | 100% | Erlang provides a built-in function for this exact problem |
 
 * there is (significant) variation in the runtime performance on Leetcode
 

--- a/lib/leetcode/p014.ex
+++ b/lib/leetcode/p014.ex
@@ -1,0 +1,19 @@
+defmodule Leetcode.P014 do
+  @moduledoc """
+  Write a function to find the longest common prefix string amongst an array of strings.
+
+  If there is no common prefix, return an empty string "".
+
+  Constraints:
+
+    1 <= strs.length <= 200
+    0 <= strs[i].length <= 200
+    strs[i] consists of only lowercase English letters if it is non-empty.
+
+  """
+
+  @spec longest_common_prefix(strs :: [String.t()]) :: String.t()
+  def longest_common_prefix(strs) do
+    :binary.part(hd(strs), 0, :binary.longest_common_prefix(strs))
+  end
+end

--- a/lib/leetcode/p014.md
+++ b/lib/leetcode/p014.md
@@ -1,0 +1,9 @@
+# Discussion
+
+Note, I originally solved this using recursion, but then saw that there was a built-in function for this exact purpose! 😄
+
+The solution simply:
+1. Uses `:binary.longest_common_prefix/1` to get the length of the common prefix
+2. Extracts that prefix from the first string using `:binary.part/3`
+
+This approach is both the most concise and most performant solution, demonstrating the power of using the right BIF for the job. The entire algorithm is implemented in a single line of meaningful code.

--- a/test/leetcode/p014_test.exs
+++ b/test/leetcode/p014_test.exs
@@ -1,0 +1,13 @@
+defmodule Leetcode.P014Test do
+  use ExUnit.Case
+
+  alias Leetcode.P014
+
+  describe "longest_common_prefix/1" do
+    test "returns the longest common prefix for a list of strings" do
+      assert P014.longest_common_prefix([""]) == ""
+      assert P014.longest_common_prefix(["flower", "flow", "flight"]) == "fl"
+      assert P014.longest_common_prefix(["dog", "racecar", "car"]) == ""
+    end
+  end
+end


### PR DESCRIPTION
This pull request introduces a solution for the "Longest Common Prefix" problem (`P014`) in Erlang, leveraging a built-in function for optimal performance. The changes include the implementation of the solution, documentation, tests, and an update to the `README.md` file.

### Problem Implementation:

* [`lib/leetcode/p014.ex`](diffhunk://#diff-4ac8cba647cbe077b8c7207d9a4abb0c9445d54e02dc0176c703965710f2bc7fR1-R19): Added the `Leetcode.P014` module to solve the "Longest Common Prefix" problem using the built-in function `:binary.longest_common_prefix/1`. The solution is concise and efficient, utilizing `:binary.part/3` for extracting the prefix.

### Documentation:

* [`lib/leetcode/p014.md`](diffhunk://#diff-1783e2d909d67fe5887c60081c65f939f2c0ec4aeb35dfa3212be9a953bfcc44R1-R9): Documented the solution approach, highlighting the use of Erlang's built-in functions for performance and simplicity. The discussion explains the transition from recursion to using `:binary.longest_common_prefix/1`.

### Testing:

* [`test/leetcode/p014_test.exs`](diffhunk://#diff-087228126ee68fd91c7abd6bbcce4a70707cc1f05cb467f343c9e74e24e139b5R1-R13): Added unit tests for the `longest_common_prefix/1` function to validate its behavior with various input cases, including edge cases like empty strings and no common prefix.

### README Update:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R26): Updated the problem list to include `P014 - Longest Common Prefix` with a note on Erlang's built-in function usage for solving the problem.